### PR TITLE
Change to serialization of data from pfm.finish

### DIFF
--- a/lib/parallel/forkmanager.rb
+++ b/lib/parallel/forkmanager.rb
@@ -651,7 +651,7 @@ module Parallel
         id = @processes.delete(kid)
 
         # Retrieve child data structure, if any.
-        the_retr_data = {}
+        the_retr_data = nil
         the_tempfile = "#{@tempdir}Parallel-ForkManager-#{$PID}-#{kid}.txt"
 
         begin
@@ -992,7 +992,7 @@ module Parallel
       return 1 if @serializer.nil?
 
       File.open(store_tempfile, "wb") do |f|
-        f.write(@serializer.serialize(@data_structure.to_hash))
+        f.write(@serializer.serialize(@data_structure))
       end
       return 1
 

--- a/test/test_parallel_fork_manager/test_serialization.rb
+++ b/test/test_parallel_fork_manager/test_serialization.rb
@@ -5,7 +5,7 @@ require "minitest_helper"
 
 module TestParallelForkManager
   class TestSerialization < Minitest::Test
-    FINISH_DATA = { foo: "bar".freeze, baz: nil }.freeze
+    DEFAULT_RETURN = { foo: "bar".freeze, baz: nil }.freeze
 
     def test_marshal
       run_test(params: { "serialize_as" => "marshal" })
@@ -31,27 +31,35 @@ module TestParallelForkManager
       run_test(params: { "foo" => "bar" })
 
       # If we run with no parmeters then the serializer isn't set up, so we get
-      # an empty hash back.
-      run_test(expected: {})
+      # nil back.
+      run_test(expected: nil)
+    end
+
+    def test_non_hash_data_return
+      data = "This is a string"
+      run_test(params: { "serialize_as" => "yaml" },
+               return: data,
+               expected: data)
     end
 
     def run_test(args = {})
       params = args.fetch(:params, {})
-      expected = args.fetch(:expected, FINISH_DATA)
+      return_data = args.fetch(:return, DEFAULT_RETURN)
+      expected = args.fetch(:expected, DEFAULT_RETURN)
 
       pfm = Parallel::ForkManager.new(1, params)
-      returned_ds = nil
-      pfm.run_on_finish do |pid, exit_code, ident, exit_signal, core_dump, ds|
-        returned_ds = ds
+      returned_data = nil
+      pfm.run_on_finish do |_pid, _exit_code, _ident, _exit_signal, _core_dump, data|
+        returned_data = data
       end
 
       unless pfm.start
         # ... in the child ...
-        pfm.finish(0, FINISH_DATA)
+        pfm.finish(0, return_data)
       end
       pfm.wait_all_children
 
-      assert_equal expected, returned_ds
+      assert_equal expected, returned_data
     end
   end
 end


### PR DESCRIPTION
This removes a call to `to_hash` from the data serializer because it
breaks the example where children can return a simple string.

If no data is returned then the data parameter to run_on_finish is nil.
